### PR TITLE
Extra verbosity & prebuilt packaging support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#rubyenv
+# rubyenv
 
 This tool is inspired by [nodeenv](https://github.com/ekalinin/nodeenv) and allows you to install ruby into your virtualenvs.
 

--- a/rubyenv/app.py
+++ b/rubyenv/app.py
@@ -11,7 +11,7 @@ import tarfile
 import six
 
 from past.builtins import basestring
-from six.moves.urllib.parse import urlparse, urlencode
+from six.moves.urllib.parse import urlparse, urlunparse, urlencode
 from six.moves.urllib.request import urlopen
 from six.moves.urllib.error import HTTPError
 
@@ -98,6 +98,8 @@ def _get_prebuilt_list():
         distro = distro.lower()
 
     for url in urlopen('https://raw.githubusercontent.com/rvm/rvm/master/config/remote').read().splitlines():
+        if (isinstance(url, bytes)):
+            url = url.decode()
         url = urlparse(url)
         path = url.path.split('/')
         if distro in path and vers in path and machine in path:
@@ -159,7 +161,7 @@ def install(ns):
             extractdir = os.path.dirname(tarpath)
             extractpath = os.path.join(extractdir, base)
 
-            resp = urlopen(urlparse.urlunparse(url))
+            resp = urlopen(urlunparse(url))
             content = resp.read()
             with open(tarpath, 'wb') as f:
                 f.write(content)
@@ -182,7 +184,10 @@ def install(ns):
             traceback.print_exc()
             sys.exit(1)
     ruby_build = os.path.join(ensure_ruby_build(), 'bin', 'ruby-build')
-    os.system('%s %s %s' % (ruby_build, ns.version, get_virtualenv_dir()))
+    cmd = '%s %s %s %s' %(ruby_build, ns.version, get_virtualenv_dir(), '-v')
+    print("Calling: %s" % cmd)
+    os.system(cmd)
+
 install.add_argument('version', type=str, nargs='?', default='latest')
 install.add_argument('--prebuilt', action='store_true')
 

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ setup(
 
     description='manage ruby in your virtualenv',
     long_description=io.open('README.md', encoding='utf-8').read(),
+    long_description_content_type='text/markdown',
     author='Tommy Wang',
     author_email='twang@august8.net',
     url='http://github.com/twang817/rubyenv',


### PR DESCRIPTION
### Changes:
 - `--prebuilt` option should now work again (fixed import of `urlunparse`)
 - Ruby builds are now invoked with `-v` argument, which prevents "fake hanging"
 - ReadMe syntax updated
 - Added `text/markdown` conent-type for long-description in `setup.py` (for PyPI prettier view)

Notice: Version was not updated in this PR and should be updated manually
This should fix issues #5 and #7 